### PR TITLE
Prettified links for https:// links and not only http://

### DIFF
--- a/src/tiddlers/system/plugins/TheDiveO/FontAwesome/styles/extlinks/GitHub.tid
+++ b/src/tiddlers/system/plugins/TheDiveO/FontAwesome/styles/extlinks/GitHub.tid
@@ -10,7 +10,7 @@ type: text/vnd.tiddlywiki
 <$set name="cfg" value=<<fa5-cfgpath "decorate-wk-extlinks">> >
 <$list filter=<<fa5-cfgfilterexpr>> >
 
-a[href^="http://"][href*="github.com"]:before {
+a[href^="https://"][href*="github.com"]:before, a[href^="http://"][href*="github.com"]:before {
   <<fa-plugin-font-brands>>
   font-size: 90%;
   content: '\f09b\202f';

--- a/src/tiddlers/system/plugins/TheDiveO/FontAwesome/styles/extlinks/Wikipedia.tid
+++ b/src/tiddlers/system/plugins/TheDiveO/FontAwesome/styles/extlinks/Wikipedia.tid
@@ -9,7 +9,7 @@ type: text/vnd.tiddlywiki
 <$set name="cfg" value=<<fa5-cfgpath "decorate-wk-extlinks">> >
 <$list filter=<<fa5-cfgfilterexpr>> >
 
-a[href^="http://"][href*=".wikipedia.org"]:before {
+a[href^="https://"][href*=".wikipedia.org"]:before, a[href^="http://"][href*=".wikipedia.org"]:before {
   <<fa-plugin-font-brands>>
   font-size: 90%;
   content: '[\f266]\202f';


### PR DESCRIPTION
Currently Github and Wikipedia links are prettified only for http:// links. This very basic pull request corrects this behaviour, extending it to https:// links. Thanks!